### PR TITLE
Use NLnet Labs GH org wide reusable Rust CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,3 +6,4 @@ jobs:
     uses: NLnetLabs/.github/.github/workflows/rust-ci.yml@main
     with:
       rust_msrv: 1.71
+      test_minimal_versions: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,6 @@ on: [push, pull_request]
 jobs:
   test:
     name: build and test
-    uses: NLnetLabs/.github/.github/workflows/rust-ci.yml@main
+    uses: NLnetLabs/.github/.github/workflows/rust-ci.yml@1e3b6b3
     with:
       rust_msrv: 1.71

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,6 @@ on: [push, pull_request]
 jobs:
   test:
     name: build and test
-    uses: NLnetLabs/.github/.github/workflows/rust-ci.yml
+    uses: NLnetLabs/.github/.github/workflows/rust-ci.yml@main
     with:
       rust_msrv: 1.71

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,71 +2,7 @@ name: ci
 on: [push, pull_request]
 jobs:
   test:
-    name: test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.71, stable, beta]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v1
-      - name: Install Rust
-        uses: hecrj/setup-rust-action@v1
-        with:
-          rust-version: ${{ matrix.rust }}
-
-      # Clippy.
-      #
-      # We run Clippy for stable and beta only, to minimize the possibility of a
-      # lint requiring something in the MSRV but the opposite thing in stable,
-      # or vice versa.
-      #
-      # For stable, error out on warnings.
-      - if: matrix.rust == 'stable'
-        run: |
-          rustup component add clippy
-          cargo clippy --all --all-features -- -D warnings -W clippy::cargo
-
-      - if: matrix.rust == 'beta'
-        run: rustup component add clippy
-
-      # For beta, turn warnings into GitHub annotations.
-      - if: matrix.rust == 'beta'
-        uses: mathiasvr/command-output@v2.0.0
-        id: clippy_beta
-        with:
-          run: |
-            # We can warn on additional lints. cargo::nursery might make sense.
-            # XXX currently this only shows the first line of output. Also see
-            # https://github.com/actions/toolkit/issues/193
-            # Replacing '\n' with "%0A" might be a workaround.
-            cargo clippy --all --all-features -q --message-format short -- \
-            -W clippy::cargo # -W clippy::nursery
-
-      - if: ${{ steps.clippy_beta.outputs.stderr }}
-        env:
-          clippy_warnings: ${{ steps.clippy_beta.outputs.stderr }}
-        run: echo "::warning ::$clippy_warnings"
-
-
-      # Because of all the features, we run build and test twice -- once with
-      # full features and once without any features at all -- to make it more
-      # likely that everything works.
-
-      # Build
-      - run: cargo build --verbose --all --all-features
-      - run: cargo build --verbose --all
-
-      # Test
-      - run: cargo test --verbose --all --all-features
-      - run: cargo test --verbose --all
-
-      # Test using minimal dependency versions from Cargo.toml
-      - if: matrix.rust != 'beta'
-        run: |
-          rustup toolchain install nightly
-          cargo +nightly update -Z minimal-versions
-          cargo build --verbose --all --all-features
-          cargo test --verbose --all --all-features
-        name: Check and test with minimal-versions
+    name: build and test
+    uses: NLnetLabs/.github/.github/workflows/rust-ci.yml
+    with:
+      rust_msrv: 1.71

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: ci
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   test:
     name: build and test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,6 @@ on: [push, pull_request]
 jobs:
   test:
     name: build and test
-    uses: NLnetLabs/.github/.github/workflows/rust-ci.yml@1e3b6b3
+    uses: NLnetLabs/.github/.github/workflows/rust-ci.yml@main
     with:
       rust_msrv: 1.71


### PR DESCRIPTION
This PR replaces the per project replica of our standard approach to building and testing Rust projects with a wrapper workflow that invokes a central copy of a reusable workflow so that fixes and improvements are received automatically in projects for which it is suited, avoiding becoming stale in older projects when improvements are only made to new copies of the workflow in new projects.

The invoked reusable workflow can be found here:
- https://github.com/NLnetLabs/.github/blob/main/.github/workflows/rust-ci.yml

To make it easier to add the workflow to a Rust project there is also a GH Starter Workflow defined here:
- https://github.com/NLnetLabs/.github/blob/main/workflow-templates/rust-ci.yml
- https://github.com/NLnetLabs/.github/blob/main/workflow-templates/rust-ci.properties.json

You can see the Starter Workflow available here:
- https://github.com/NLnetLabs/inetnum/actions/new

Which should appear like this:
<img width="827" alt="afbeelding" src="https://github.com/NLnetLabs/inetnum/assets/3304436/7573c6a4-2e29-4ba1-b095-6b68c42eef60">
