### PR TITLE
Fix panic in ASN parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,5 +5,5 @@ jobs:
     name: build and test
     uses: NLnetLabs/.github/.github/workflows/rust-ci.yml@main
     with:
-      rust_msrv: 1.71
+      rust_msrv: "1.80"
       test_minimal_versions: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Types for IP address prefixes and ASNs."
 documentation = "https://docs.rs/inetnum/"
 repository = "https://github.com/NLnetLabs/inetnum"
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.80"
 keywords = ["routing", "bgp", "rpki"]
 license = "BSD-3-Clause"
 

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "inetnum-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.inetnum]
+path = ".."
+
+[[bin]]
+name = "parse_asn"
+path = "fuzz_targets/parse_asn.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "parse_asn16"
+path = "fuzz_targets/parse_asn16.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/parse_asn.rs
+++ b/fuzz/fuzz_targets/parse_asn.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use std::str::FromStr;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = inetnum::asn::Asn::from_str(s);
+    }
+});

--- a/fuzz/fuzz_targets/parse_asn.rs
+++ b/fuzz/fuzz_targets/parse_asn.rs
@@ -3,8 +3,6 @@
 use libfuzzer_sys::fuzz_target;
 use std::str::FromStr;
 
-fuzz_target!(|data: &[u8]| {
-    if let Ok(s) = std::str::from_utf8(data) {
-        let _ = inetnum::asn::Asn::from_str(s);
-    }
+fuzz_target!(|data: &str| {
+    let _ = inetnum::asn::Asn::from_str(data);
 });

--- a/fuzz/fuzz_targets/parse_asn16.rs
+++ b/fuzz/fuzz_targets/parse_asn16.rs
@@ -3,8 +3,6 @@
 use libfuzzer_sys::fuzz_target;
 use std::str::FromStr;
 
-fuzz_target!(|data: &[u8]| {
-    if let Ok(s) = std::str::from_utf8(data) {
-        let _ = inetnum::asn::Asn16::from_str(s);
-    }
+fuzz_target!(|data: &str| {
+    let _ = inetnum::asn::Asn16::from_str(data);
 });

--- a/fuzz/fuzz_targets/parse_asn16.rs
+++ b/fuzz/fuzz_targets/parse_asn16.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use std::str::FromStr;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = inetnum::asn::Asn16::from_str(s);
+    }
+});

--- a/src/asn.rs
+++ b/src/asn.rs
@@ -81,13 +81,9 @@ impl FromStr for Asn {
     type Err = ParseAsnError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = if s.len() > 2 && s[..2].eq_ignore_ascii_case("as") {
-            &s[2..]
-        } else {
-            s
-        };
-
-        u32::from_str(s).map(Asn).map_err(|_| ParseAsnError)
+        u32::from_str(strip_as(s))
+            .map(Asn)
+            .map_err(|_| ParseAsnError)
     }
 }
 
@@ -321,11 +317,12 @@ impl From<u16> for Asn16 {
 }
 
 fn strip_as(s: &str) -> &str {
-    s.strip_prefix("AS")
-        .or_else(|| s.strip_prefix("as"))
-        .or_else(|| s.strip_prefix("As"))
-        .or_else(|| s.strip_prefix("aS"))
-        .unwrap_or(s)
+    if let Some((prefix, rest)) = s.split_at_checked(2) {
+        if prefix.eq_ignore_ascii_case("as") {
+            return rest;
+        }
+    };
+    s
 }
 
 impl FromStr for Asn16 {


### PR DESCRIPTION
And add some fuzzing to be sure that this patch fixes the panic.

The fix uses `std::split_at_checked` stabilized in 1.80 so I bumped the MSRV to that.